### PR TITLE
Player2に関するスクリプト

### DIFF
--- a/Assets/Free Stylized Skybox/Panoramic/Materials/Sky_Anime_03_Day_a.mat
+++ b/Assets/Free Stylized Skybox/Panoramic/Materials/Sky_Anime_03_Day_a.mat
@@ -77,7 +77,7 @@ Material:
     - _OcclusionStrength: 1
     - _QueueOffset: 0
     - _ReceiveShadows: 1
-    - _Rotation: 218.7898
+    - _Rotation: 329.68127
     - _Smoothness: 0.5
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1

--- a/Assets/Prefabs/AfterGrass.prefab
+++ b/Assets/Prefabs/AfterGrass.prefab
@@ -91,7 +91,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3934356072360846589}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: cd44dddcec87b4366b1226b3685c0183, type: 3}
   m_Name: 

--- a/Assets/Prefabs/AfterGrass.prefab
+++ b/Assets/Prefabs/AfterGrass.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 8777919845342602140}
   - component: {fileID: 1418981702128653370}
   - component: {fileID: 8146975636141294185}
+  - component: {fileID: -4553370793343035322}
   m_Layer: 0
   m_Name: AfterGrass
   m_TagString: AfterGrass
@@ -98,3 +99,24 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   lifetime: 10
   spawnPrefab: {fileID: 2527857454293643736, guid: b43bad4768d95495482cc752d8dd43d6, type: 3}
+--- !u!65 &-4553370793343035322
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3934356072360846589}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1.2008319, y: 1.1704781, z: 3}
+  m_Center: {x: 0.07310024, y: 0.0040371725, z: 0.047558587}

--- a/Assets/Scenes/main.unity
+++ b/Assets/Scenes/main.unity
@@ -3928,6 +3928,7 @@ GameObject:
   - component: {fileID: 1033765946}
   - component: {fileID: 1033765945}
   - component: {fileID: 1033765948}
+  - component: {fileID: 1033765949}
   m_Layer: 0
   m_Name: Zyouro
   m_TagString: Untagged
@@ -3965,7 +3966,7 @@ BoxCollider:
     serializedVersion: 2
     m_Bits: 0
   m_LayerOverridePriority: 0
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
@@ -4048,6 +4049,19 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 116
   m_CollisionDetection: 0
+--- !u!114 &1033765949
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1033765943}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 958a995a5d0534cb08fabc350c3db4ef, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  grass: {fileID: 747360759}
 --- !u!1 &1049466686
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/main.unity
+++ b/Assets/Scenes/main.unity
@@ -1294,13 +1294,13 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 345832273}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8de9ee434b41d46d99275483c6438325, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  blockParent: {fileID: 2909061866247334754, guid: b43bad4768d95495482cc752d8dd43d6, type: 3}
-  blockPrefab_Grass: {fileID: 2527857454293643736, guid: b43bad4768d95495482cc752d8dd43d6, type: 3}
+  blockParent: {fileID: 747360764}
+  blockPrefab_Grass: {fileID: 747360759}
 --- !u!114 &345832277
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2679,6 +2679,16 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   baudRate: 115200
   Settingsflag: 0
+--- !u!1 &747360759 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2527857454293643736, guid: b43bad4768d95495482cc752d8dd43d6, type: 3}
+  m_PrefabInstance: {fileID: 7043817301802584681}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &747360764 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2909061866247334754, guid: b43bad4768d95495482cc752d8dd43d6, type: 3}
+  m_PrefabInstance: {fileID: 7043817301802584681}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &760531041
 GameObject:
   m_ObjectHideFlags: 0
@@ -2871,6 +2881,52 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d8969eedf7d21434690b0c0a27db2b22, type: 3}
+--- !u!1 &765711186
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 765711188}
+  - component: {fileID: 765711187}
+  m_Layer: 0
+  m_Name: TestManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &765711187
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 765711186}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3eb1440bbb9224c57bda2e6a609d8100, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  blockParent: {fileID: 6975903607536448097, guid: b961387b7b3a646efb15721f5ac34528, type: 3}
+  blockPrefab_AfterGrass: {fileID: 3934356072360846589, guid: b961387b7b3a646efb15721f5ac34528, type: 3}
+--- !u!4 &765711188
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 765711186}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.5600014, y: 30.000002, z: 181.82555}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &788718726
 GameObject:
   m_ObjectHideFlags: 0
@@ -3871,6 +3927,7 @@ GameObject:
   - component: {fileID: 1033765947}
   - component: {fileID: 1033765946}
   - component: {fileID: 1033765945}
+  - component: {fileID: 1033765948}
   m_Layer: 0
   m_Name: Zyouro
   m_TagString: Untagged
@@ -3964,6 +4021,33 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1033765943}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!54 &1033765948
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1033765943}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 116
+  m_CollisionDetection: 0
 --- !u!1 &1049466686
 GameObject:
   m_ObjectHideFlags: 0
@@ -5450,7 +5534,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1547051172}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 96ec56fea9fbc4b4685d6bd931c4286f, type: 3}
   m_Name: 
@@ -6108,6 +6192,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1753762141}
+  - component: {fileID: 1753762142}
+  - component: {fileID: 1753762143}
   m_Layer: 0
   m_Name: Player2
   m_TagString: Untagged
@@ -6136,6 +6222,32 @@ RectTransform:
   m_AnchoredPosition: {x: -0.56, y: 30}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1753762142
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1753762140}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e68fb7c9977514900a2bb4c9b20f596e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  areaCollider: {fileID: 702842738}
+--- !u!114 &1753762143
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1753762140}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f8dab67606eda4b7381815ea0ed014a8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  moveSpeed: 0.001
 --- !u!1 &1782157031
 GameObject:
   m_ObjectHideFlags: 0
@@ -8479,6 +8591,7 @@ SceneRoots:
   - {fileID: 739072887}
   - {fileID: 345832275}
   - {fileID: 1059184519}
+  - {fileID: 765711188}
   - {fileID: 69634656}
   - {fileID: 8041157392083583748}
   - {fileID: 262840764}

--- a/Assets/Scripts/Test.meta
+++ b/Assets/Scripts/Test.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c4c8f9e067b594456b19d4510d68b01e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Test/CreateAfterGrassField.cs
+++ b/Assets/Scripts/Test/CreateAfterGrassField.cs
@@ -1,0 +1,35 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CreateAfterGrassField : MonoBehaviour
+{
+    public Transform blockParent;
+    public GameObject blockPrefab_AfterGrass;
+
+    public const int MAP_WIDTH = 500;
+    public const int MAP_HEIGHT = 250;
+
+    void Start()
+    {
+        Vector3 defaultPos = new Vector3(0.0f, 13.5f, 0.0f);
+        defaultPos.x = -(MAP_WIDTH / 2);
+        defaultPos.z = -(MAP_HEIGHT / 2);
+
+
+        // ここがワールドのブロックのパターンを生成するところ
+        for (int i = 0; i < MAP_WIDTH; i += 40)
+        {
+            for (int j = 0; j < MAP_HEIGHT; j += 40)
+            {
+                Vector3 pos = defaultPos;
+                pos.x += i;
+                pos.z += j;
+
+                GameObject obj;
+                obj = Instantiate(blockPrefab_AfterGrass, blockParent);
+                obj.transform.position = pos;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Test/CreateAfterGrassField.cs.meta
+++ b/Assets/Scripts/Test/CreateAfterGrassField.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3eb1440bbb9224c57bda2e6a609d8100
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Zyouro.meta
+++ b/Assets/Scripts/Zyouro.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a3a01fe6db74b4926a3c4f32cfab9d43
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Zyouro/Controller.cs
+++ b/Assets/Scripts/Zyouro/Controller.cs
@@ -1,0 +1,50 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Controller : MonoBehaviour
+{
+    public float moveSpeed = 0.001f;
+    private Vector3 lastMousePosition;
+
+    void Start()
+    {
+        // 初期化時にマウスの位置を保存
+        lastMousePosition = Input.mousePosition;
+    }
+
+    void Update()
+    {
+        if (ReadyToStart.flag)
+        {
+            float rotationSpeed = 10f; // 回転速度
+
+            // 現在の位置を取得
+            Vector3 currentPosition = transform.position;
+
+            // 十字キーでの進行方向変更（回転）
+            float h = Input.GetAxis("Horizontal"); // 左右キーの取得
+            transform.Rotate(0, rotationSpeed * h * 0.1f, 0);
+
+            // Debug.Log(h);
+
+            // マウスのX方向の移動距離を計算
+            Vector3 currentMousePosition = Input.mousePosition;
+            float mouseDeltaX = currentMousePosition.x - lastMousePosition.x;
+
+            // マウスの移動に応じてプレイヤーを回転
+            transform.Rotate(0, mouseDeltaX * rotationSpeed * 0.001f, 0);
+
+            // マウスの移動距離に応じて前進
+            if (Mathf.Abs(mouseDeltaX) > 0)
+            {
+                transform.position += transform.forward * Mathf.Abs(mouseDeltaX) * moveSpeed * 10;
+                // 高さは固定
+                transform.position = new Vector3(transform.position.x, 30, transform.position.z);
+            }
+
+            // 現在のマウス位置を次のフレーム用に保存
+            lastMousePosition = currentMousePosition;
+        }
+    }
+}

--- a/Assets/Scripts/Zyouro/Controller.cs.meta
+++ b/Assets/Scripts/Zyouro/Controller.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f8dab67606eda4b7381815ea0ed014a8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Zyouro/SpawnGrass.cs
+++ b/Assets/Scripts/Zyouro/SpawnGrass.cs
@@ -1,0 +1,18 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SpawnGrass : MonoBehaviour
+{
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/Assets/Scripts/Zyouro/SpawnGrass.cs
+++ b/Assets/Scripts/Zyouro/SpawnGrass.cs
@@ -4,15 +4,33 @@ using UnityEngine;
 
 public class SpawnGrass : MonoBehaviour
 {
+    private int isCollide = 0;
+    public GameObject grass;
     // Start is called before the first frame update
     void Start()
     {
-        
+
     }
 
     // Update is called once per frame
     void Update()
     {
-        
+        if (isCollide == 1)
+        {
+            Vector3 pos = transform.position;
+            pos.y = 13.5f;
+            Instantiate(grass, pos, Quaternion.Euler(270, 0, 0));
+            isCollide = 0;
+        }
+
+    }
+    private void OnTriggerEnter(Collider other)
+    {
+        if (other.gameObject.tag == "AfterGrass")
+        {
+            // Debug.Log("Playerが草に触れました");
+            Destroy(other.gameObject);
+            isCollide = 1;
+        }
     }
 }

--- a/Assets/Scripts/Zyouro/SpawnGrass.cs.meta
+++ b/Assets/Scripts/Zyouro/SpawnGrass.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 958a995a5d0534cb08fabc350c3db4ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Player2に関するスクリプト
- Player2の移動・操作
- Player2の機能（草の生成）

## Player2の移動・操作
`Assets/Scripts/Zyouro/Controller.cs`
Player1と同様の移動・操作方法です．
※Player2に関するスクリプトは`Assets/Scripts/Zyouro`に配置しています．（Player2の方が良かったかも...）

## Player2の機能（草の生成）
`Assets/Scripts/Zyouro/SpawnGrass.cs`
AfterGrassに衝突したらGrassを生成します．
草を刈られていない状態がAfterGrassになります．

https://github.com/user-attachments/assets/7b3b6f56-5270-4f22-b371-0ba0ce24b4ef

つまり，以下のゲームフローを想定しています．
- Player1: Grass -> AfterGrass
- Player2: AfterGrass -> Grass

AfterGrassの判定のためPrefabのColliderを編集しています．

## その他
### テスト環境の設定
 動作確認にあたって，テスト用の環境が欲しかったので，`TestManager`と`Assets/Scripts/Test`を作成しました．
現在はゲーム開始時にフィールドの半分の範囲にAfterGrassを生成するScriptがあります．

![](https://github.com/user-attachments/assets/53eb321f-869f-4227-ad67-b6272bd6883f)

各自いい感じに使ってください．

### 動作確認にあたって
動作確認にあたって複数の機能を一時的に切りました．（勝手でごめん）

![](https://github.com/user-attachments/assets/d0ffab39-6e54-4a65-b7c0-344644246c1e)
CreateFieldを切りました

![](https://github.com/user-attachments/assets/f2dd25dc-f0c6-4478-959b-1f60cdc77b66)
OperationSettingsを切りました

各自作業する際にはこれらの機能が切られていることに注意してください．

### 整理したくね
いらないスクリプトやオブジェクトが増えてきたので整理したくなってきました．